### PR TITLE
Slash Command option length support for STRING option types (#1339)

### DIFF
--- a/DSharpPlus.SlashCommands/Attributes/MaximumLengthAttribute.cs
+++ b/DSharpPlus.SlashCommands/Attributes/MaximumLengthAttribute.cs
@@ -1,0 +1,47 @@
+﻿// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2022 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+
+namespace DSharpPlus.SlashCommands
+{
+    /// <summary>
+    /// Sets a maximum allowed length for this slash command option. Only valid for <see cref="string"/> parameters.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
+    public class MaximumLengthAttribute : Attribute
+    {
+        /// <summary>
+        /// The value.
+        /// </summary>
+        public int Value { get; internal set; }
+
+        /// <summary>
+        /// Sets a maximum allowed length for this slash command option. Only valid for <see cref="string"/> parameters.
+        /// </summary>
+        public MaximumLengthAttribute(int value)
+        {
+            this.Value = value;
+        }
+    }
+}

--- a/DSharpPlus.SlashCommands/Attributes/MinimumLengthAttribute.cs
+++ b/DSharpPlus.SlashCommands/Attributes/MinimumLengthAttribute.cs
@@ -1,0 +1,47 @@
+﻿// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2022 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+
+namespace DSharpPlus.SlashCommands
+{
+    /// <summary>
+    /// Sets a minimum allowed length for this slash command option. Only valid for <see cref="string"/> parameters.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
+    public class MinimumLengthAttribute : Attribute
+    {
+        /// <summary>
+        /// The value.
+        /// </summary>
+        public int Value { get; internal set; }
+
+        /// <summary>
+        /// Sets a minimum allowed length for this slash command option. Only valid for <see cref="string"/> parameters.
+        /// </summary>
+        public MinimumLengthAttribute(int value)
+        {
+            this.Value = value;
+        }
+    }
+}

--- a/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
+++ b/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
@@ -430,8 +430,11 @@ namespace DSharpPlus.SlashCommands
 
                 var channelTypes = parameter.GetCustomAttribute<ChannelTypesAttribute>()?.ChannelTypes ?? null;
 
-                var minimum = parameter.GetCustomAttribute<MinimumAttribute>()?.Value ?? null;
-                var maximum = parameter.GetCustomAttribute<MaximumAttribute>()?.Value ?? null;
+                var minimumValue = parameter.GetCustomAttribute<MinimumAttribute>()?.Value ?? null;
+                var maximumValue = parameter.GetCustomAttribute<MaximumAttribute>()?.Value ?? null;
+
+                var minimumLength = parameter.GetCustomAttribute<MinimumLengthAttribute>()?.Value ?? null;
+                var maximumLength = parameter.GetCustomAttribute<MaximumLengthAttribute>()?.Value ?? null;
 
                 var nameLocalizations = this.GetNameLocalizations(parameter);
                 var descriptionLocalizations = this.GetDescriptionLocalizations(parameter);
@@ -440,7 +443,7 @@ namespace DSharpPlus.SlashCommands
                 if (autocompleteAttribute != null && autocompleteAttribute.Provider.GetMethod(nameof(IAutocompleteProvider.Provider)) == null)
                     throw new ArgumentException("Autocomplete providers must inherit from IAutocompleteProvider.");
 
-                options.Add(new DiscordApplicationCommandOption(optionattribute.Name, optionattribute.Description, parametertype, !parameter.IsOptional, choices, null, channelTypes, autocompleteAttribute != null || optionattribute.Autocomplete, minimum, maximum, nameLocalizations, descriptionLocalizations));
+                options.Add(new DiscordApplicationCommandOption(optionattribute.Name, optionattribute.Description, parametertype, !parameter.IsOptional, choices, null, channelTypes, (autocompleteAttribute != null || optionattribute.Autocomplete), minimumValue, maximumValue, nameLocalizations, descriptionLocalizations, minimumLength, maximumLength));
             }
 
             return options;

--- a/DSharpPlus.Test/SlashCommandMinMaxLengthTest.cs
+++ b/DSharpPlus.Test/SlashCommandMinMaxLengthTest.cs
@@ -1,0 +1,36 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2022 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Threading.Tasks;
+using DSharpPlus.Entities;
+using DSharpPlus.SlashCommands;
+
+namespace DSharpPlus.Test
+{
+    public class SlashCommandMinMaxLengthTest : ApplicationCommandModule
+    {
+        [SlashCommand("minmaxlength", "testing min and max length")]
+        public async Task MinMaxAsync(InteractionContext ctx, [Option("value", "value with limits")][MinimumLength(5), MaximumLength(7)] string thing)
+            => await ctx.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource, new DiscordInteractionResponseBuilder().WithContent(thing));
+    }
+}

--- a/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommandOption.cs
+++ b/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommandOption.cs
@@ -95,6 +95,18 @@ namespace DSharpPlus.Entities
         public object MaxValue { get; internal set; }
 
         /// <summary>
+        /// Gets the minimum allowed length for this slash command parameter.
+        /// </summary>
+        [JsonProperty("min_length", NullValueHandling = NullValueHandling.Ignore)]
+        public int? MinLength { get; internal set; }
+
+        /// <summary>
+        /// Gets the maximum allowed length for this slash command parameter.
+        /// </summary>
+        [JsonProperty("max_length", NullValueHandling = NullValueHandling.Ignore)]
+        public int? MaxLength { get; internal set; }
+
+        /// <summary>
         /// Localized names for this option.
         /// </summary>
         [JsonProperty("name_localizations", NullValueHandling = NullValueHandling.Include)]
@@ -120,7 +132,9 @@ namespace DSharpPlus.Entities
         /// <param name="minValue">The minimum value for this parameter. Only valid for types <see cref="ApplicationCommandOptionType.Integer"/> or <see cref="ApplicationCommandOptionType.Number"/>.</param>
         /// <param name="maxValue">The maximum value for this parameter. Only valid for types <see cref="ApplicationCommandOptionType.Integer"/> or <see cref="ApplicationCommandOptionType.Number"/>.</param>
         /// <param name="name_localizations">Name localizations for this parameter.</param>
-        public DiscordApplicationCommandOption(string name, string description, ApplicationCommandOptionType type, bool? required = null, IEnumerable<DiscordApplicationCommandOptionChoice> choices = null, IEnumerable<DiscordApplicationCommandOption> options = null, IEnumerable<ChannelType> channelTypes = null, bool? autocomplete = null, object minValue = null, object maxValue = null, IReadOnlyDictionary<string, string> name_localizations = null, IReadOnlyDictionary<string, string> description_localizations = null)
+        /// <param name="minLength">The minimum allowed length for this parameter. Only valid for type <see cref="ApplicationCommandOptionType.String"/>.</param>
+        /// <param name="maxLength">The maximum allowed length for this parameter. Only valid for type <see cref="ApplicationCommandOptionType.String"/>.</param>
+        public DiscordApplicationCommandOption(string name, string description, ApplicationCommandOptionType type, bool? required = null, IEnumerable<DiscordApplicationCommandOptionChoice> choices = null, IEnumerable<DiscordApplicationCommandOption> options = null, IEnumerable<ChannelType> channelTypes = null, bool? autocomplete = null, object minValue = null, object maxValue = null, IReadOnlyDictionary<string, string> name_localizations = null, IReadOnlyDictionary<string, string> description_localizations = null, int? minLength = null, int? maxLength = null)
         {
             if (!Utilities.IsValidSlashCommandName(name))
                 throw new ArgumentException("Invalid slash command option name specified. It must be below 32 characters and not contain any whitespace.", nameof(name));
@@ -145,6 +159,8 @@ namespace DSharpPlus.Entities
             this.ChannelTypes = channelTypeList;
             this.MinValue = minValue;
             this.MaxValue = maxValue;
+            this.MinLength = minLength;
+            this.MaxLength = maxLength;
             this.NameLocalizations = name_localizations;
             this.DescriptionLocalizations = description_localizations;
         }


### PR DESCRIPTION
* Slash Command Option length support for STRING option types

mostly a copy paste from min/max for numbers but eh it does the job
i think

it did when i tested it!

* rename variables

Make sure you familiarize yourself with our contributing guidelines.

# Summary
Fixes #issue/Resolves #issue/Implements functionality. Short description of changes.

# Details
You can put detailed description of the changes in here.

# Changes proposed
* Outline
* Your 
* Changes
* Here

# Notes
Any additional notes go here.